### PR TITLE
Prevent the need for repetition in sample definitions

### DIFF
--- a/abe/mocks.py
+++ b/abe/mocks.py
@@ -20,5 +20,24 @@ class AbeMock(object):
 
         # Make all example requests and reponses accessible via dot syntax
         # (e.g. mock["OK"].request.status)
-        for k, v in self.examples.items():
-            self.examples[k] = dotify(v)
+        for key, value in self.examples.items():
+            # Add the request URL automatically if missing.
+            self._feed_inherited_fields(value, 'request', ['url', 'method'])
+            self.examples[key] = dotify(value)
+
+    def _feed_inherited_fields(self, value, where, inheritable):
+        """
+        If missing in request or response, some fields are inherited.
+
+        URL and method are defined at the top level. They don't need to be
+        redefined in example requests or responses.
+
+        :param where: 'request' or 'response'
+        :param inheritable: list of inheritable fields
+
+        """
+        if where not in value:
+            value[where] = {}
+        for key in inheritable:
+            if key not in value[where]:
+                value[where][key] = getattr(self, key)


### PR DESCRIPTION
Allow one to skip repeating the request URL in all samples, which is the case when the URL of the endpoint under tests is fixed (contains no variable parts).

E.g. this is an example from a project I'm working on:

``` json
{
    "description": "Retrieve profile of logged in user",
    "url": "/accounts/me",
    "method": "GET",
    "examples": {
        "OK": {
            "response": {
                "status": 200,
                "body": {
                    "id": 1,
                    "username": "user-0",
                    "first_name": "",
                    "last_name": "",
                    "email": "user-0@example.com"
                }
            }
        },
        "unauthenticated": {
            "description": "I am not logged in",
            "response": {
                "status": 403,
                "body": {
                    "detail": "Authentication credentials were not provided."
                }
            }
        }
    }
}
```

Before this PR, I had to write:

``` json
{
    "description": "Retrieve profile of logged in user",
    "url": "/accounts/me",
    "method": "GET",
    "examples": {
        "OK": {
            "request": {
                "url": "/accounts/me"
            },
            "response": {
                "status": 200,
                "body": {
                    "id": 1,
                    "username": "user-0",
                    "first_name": "",
                    "last_name": "",
                    "email": "user-0@example.com"
                }
            }
        },
        "unauthenticated": {
            "description": "I am not logged in",
            "request": {
                "url": "/accounts/me"
            },
            "response": {
                "status": 403,
                "body": {
                    "detail": "Authentication credentials were not provided."
                }
            }
        }
    }
}
```

...which includes some tedious repetition.
