### PR TITLE
Fix to_unicode to work for DRF hyperlink fields

### DIFF
--- a/abe/unittest.py
+++ b/abe/unittest.py
@@ -106,7 +106,8 @@ class AbeTestMixin(object):
         :param url:
             The actual URL we want to compare with the sample
         :param response:
-            The actual API response we want to match with the sample
+            The actual API response we want to match with the sample.
+            It is assumed to be a Django Rest Framework response object
         """
         sample = self.load_sample(path)
         sample_request = sample.examples[label].request
@@ -115,4 +116,5 @@ class AbeTestMixin(object):
         self.assertEqual(url, sample_request.url)
         self.assertEqual(response.status_code, sample_response.status)
         if 'body' in sample_response:
-            self.assert_data_equal(response.data, sample_response.body)
+            response_parsed = response.data
+            self.assert_data_equal(response_parsed, sample_response.body)

--- a/abe/utils.py
+++ b/abe/utils.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import decimal
 import sys
 
 _PY3 = sys.version_info >= (3, 0)
@@ -20,7 +19,7 @@ def to_unicode(data):
     """
     if isinstance(data, datetime):
         data = datetime_to_string(data)
-    elif isinstance(data, decimal.Decimal):
+    else:
         data = str(data)
 
     if not _PY3:


### PR DESCRIPTION
When using a DRF Hyperlinked serializer, those fields come up as instances of `<class 'rest_framework.relations.Hyperlink'>` and comparison failed.
