### PR TITLE
Add tests for ordering.

### DIFF
--- a/abe/unittest.py
+++ b/abe/unittest.py
@@ -36,7 +36,7 @@ class AbeTestMixin(object):
 
     def assert_data_equal(self, data1, data2):
         """
-        Two elements are recursively equal without taking order into account
+        Two elements are recursively equal
         """
         try:
             if isinstance(data1, list):
@@ -69,7 +69,7 @@ class AbeTestMixin(object):
 
     def assert_data_list_equal(self, data1, data2):
         """
-        Two lists are recursively equal without taking order into account
+        Two lists are recursively equal, including ordering.
         """
         self.assertEqual(
             len(data1), len(data2),
@@ -77,23 +77,19 @@ class AbeTestMixin(object):
                 data1, data2)
         )
 
-        data1_elements = copy(data1)
-        for element2 in data2:
-            fails, exceptions, found = [], [], False
-            while data1_elements and not found:
-                element = data1_elements.pop()
-                try:
-                    self.assert_data_equal(element, element2)
-                    found = True
-                except AssertionError as exc:
-                    exceptions.append(exc)
-                    fails.append(element)
-                    if not data1_elements:
-                        message = '\n*\n'.join(
-                            map(str, exceptions)
-                        )
-                        raise type(exceptions[0])(message)
-            data1_elements.extend(fails)
+        exceptions = []
+        for element, element2 in zip(data1, data2):
+            try:
+                self.assert_data_equal(element, element2)
+            except AssertionError as exc:
+                exceptions.append(exc)
+
+        if exceptions:
+            message = '\n*\n'.join(
+                map(str, exceptions)
+            )
+            raise type(exceptions[0])(message)
+
 
     def assert_matches_sample(self, path, label, url, response):
         """

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+
+from abe.unittest import AbeTestMixin
+
+
+class TestDataListEqual(TestCase, AbeTestMixin):
+
+
+    def test_simple_list_equality(self):
+        self.assert_data_list_equal([1, 2], [1, 2])
+
+    def test_simple_list_equality_for_ordering(self):
+        self.assertRaises(
+            AssertionError,
+            self.assert_data_list_equal, [3, 1, 2], [2, 3, 1]
+        )
+
+    def test_list_equality_nested_items(self):
+        self.assert_data_list_equal([[3, 1], 1, 2], [[3, 1], 1, 2])
+        self.assert_data_list_equal(
+            [[3, 1], {'foo': 'bar'}, 2],
+            [[3, 1], {'foo': 'bar'}, 2]
+        )
+        self.assert_data_list_equal(
+            [[3, 1], {'foo': [1, 2, 3]}, 2],
+            [[3, 1], {'foo': [1, 2, 3]}, 2]
+        )
+
+    def test_list_equality_ordering_nested_items(self):
+        nested_examples = [
+            ([[3, 1], 1, 2], [[1, 3], 1, 2]),
+            ([[3, 1], {'foo': 'bar'}, 2], [[3, 1], {'foo': 'dee'}, 2]),
+            ([[3, 1], {'foo': [1, 2, 3]}, 2], [[3, 1], {'foo': [1, 3, 2]}, 2])
+        ]
+        for data1, data2 in nested_examples:
+            self.assertRaises(
+                AssertionError,
+                self.assert_data_list_equal, data1, data2
+            )


### PR DESCRIPTION
This is an attempted fix for #5 

I'm not fully aware of the ins and outs for some of the code I've changed in the `assert_data_list_equal` method and wasn't able to verify if I had broken anything.

I've added a tests module with a few tests to show that ordering now matters to lists.
