### PR TITLE
Add support for testing headers.

### DIFF
--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -37,3 +37,37 @@ class TestDataListEqual(TestCase, AbeTestMixin):
                 AssertionError,
                 self.assert_data_list_equal, data1, data2
             )
+
+
+class TestAssertHeadersEqual(TestCase, AbeTestMixin):
+
+    def test_matches_django_test_format(self):
+        self.assert_headers_contain(
+            {'HTTP_THIS_CUSTOM_HEADER': 'Foo'},
+            {'This-Custom-Header': 'Foo'}
+        )
+
+    def test_matches_normal_header_format(self):
+        self.assert_headers_contain(
+            {'This-Custom-Header': 'Foo'},
+            {'This-Custom-Header': 'Foo'},
+        )
+
+    def test_matches_only_sample_defined_headers(self):
+        self.assert_headers_contain(
+            {'HTTP_THIS_CUSTOM_HEADER': 'Foo',
+             'HTTP_SOME_UNDEFINED_IN_SPEC_HEADER': 'Bar'},
+            {'This-Custom-Header': 'Foo'},
+        )
+
+    def test_requires_key_and_value_match(self):
+        with self.assertRaises(AssertionError):
+            self.assert_headers_contain(
+                {'HTTP_THIS_CUSTOM_HEADER': 'Bar'},
+                {'This-Custom-Header': 'Foo'},
+            )
+        with self.assertRaises(AssertionError):
+            self.assert_headers_contain(
+                {'HTTP_THIS_CUSTOM': 'Foo'},
+                {'This-Custom-Header': 'Foo'},
+            )


### PR DESCRIPTION
This allows the definition of a `'headers'` key to ABE spec files that will be compared with actual requests made.
