### PR TITLE
Alex/check post

### DIFF
--- a/abe/mocks.py
+++ b/abe/mocks.py
@@ -5,16 +5,11 @@ from supermutes.dot import dotify
 
 class AbeMock(object):
 
-    def __init__(self, filename):
+    def __init__(self, data):
         """
         Initialise an ABE mock from data.
 
-        filename is expected to be the path to an ABE file.
-
         """
-        with open(filename, 'r') as f:
-            data = json.load(f)
-
         # map JSON fields to attributes
         self.__dict__ = data
 
@@ -24,6 +19,18 @@ class AbeMock(object):
             # Add the request URL automatically if missing.
             self._feed_inherited_fields(value, 'request', ['url', 'method'])
             self.examples[key] = dotify(value)
+
+    @classmethod
+    def from_filename(cls, filename):
+        """
+        Initialise an ABE mock from a spec file.
+
+        filename is expected to be the path to an ABE file.
+
+        """
+        with open(filename, 'r') as f:
+            data = json.load(f)
+        return AbeMock(data)
 
     def _feed_inherited_fields(self, value, where, inheritable):
         """

--- a/abe/mocks.py
+++ b/abe/mocks.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from supermutes.dot import dotify
 
@@ -10,6 +11,14 @@ class AbeMock(object):
         Initialise an ABE mock from data.
 
         """
+        if not isinstance(data, dict):
+            msg = ('Instanciating an AbeMock by filename is deprecated and '
+                   'will be removed in an upcoming release. '
+                   'Use AbeMock.from_filename instead'.format(data))
+            warnings.warn(msg, DeprecationWarning)
+            with open(data, 'r') as f:
+                data = json.load(f)
+
         # map JSON fields to attributes
         self.__dict__ = data
 

--- a/tests/data/sample.json
+++ b/tests/data/sample.json
@@ -1,0 +1,34 @@
+{
+    "description": "Retrieve profile of logged in user",
+    "url": "/accounts/me",
+    "method": "GET",
+    "examples": {
+        "OK": {
+            "request": {
+                "url": "/accounts/me"
+            },
+            "response": {
+                "status": 200,
+                "body": {
+                    "id": 1,
+                    "username": "user-0",
+                    "first_name": "",
+                    "last_name": "",
+                    "email": "user-0@example.com"
+                }
+            }
+        },
+        "unauthenticated": {
+            "description": "I am not logged in",
+            "request": {
+                "url": "/accounts/me"
+            },
+            "response": {
+                "status": 403,
+                "body": {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
+        }
+    }
+}

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -1,8 +1,13 @@
+from os.path import abspath, dirname, join
 from unittest import TestCase
+import warnings
+
 from mock import Mock
 
 from abe.mocks import AbeMock
 from abe.unittest import AbeTestMixin
+
+DATA_DIR = join(dirname(abspath(__file__)), 'data')
 
 
 class TestDataListEqual(TestCase, AbeTestMixin):
@@ -134,3 +139,21 @@ class TestAssertMatchesRequest(TestCase, AbeTestMixin):
             self.assert_matches_request(
                 self.sample_request, self.mock_wsgi_request
             )
+
+
+class TestFilenameInstantiation(TestCase):
+
+    def setUp(self):
+        self.filename = join(DATA_DIR, 'sample.json')
+
+    def test_can_still_use_deprecated_instantiation(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            mock = AbeMock(self.filename)
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_from_filename(self):
+        mock = AbeMock.from_filename(self.filename)


### PR DESCRIPTION
This solves #10 

However, it also does one other things that maybe the `abe-python` project doesn't want:
- A backwards incompatible change to the function definition of `assert_matches_sample` to remove data that is derivable (ie ''url").
