### PR TITLE
Support non-strict matching of samples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ python:
 install: pip install -r test-requirements.txt
 script:
     - python -m unittest discover || python -m unittest
-    - flake8 abe
+    - flake8 abe tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ python:
 install: pip install -r test-requirements.txt
 script:
     - python -m unittest discover || python -m unittest
+    - python -m doctest abe/utils.py
     - flake8 abe tests

--- a/abe/unittest.py
+++ b/abe/unittest.py
@@ -76,9 +76,9 @@ class AbeTestMixin(object):
             msg='Number of elements mismatch: {} != {}\n'.format(
                 real.keys(), sample.keys())
         )
-        for key in real:
+        for key in sample:
+            self.assertIn(key, real)
             if key not in non_strict:
-                self.assertIn(key, sample)
                 inner_non_strict = subkeys(non_strict, key)
                 self.assert_data_equal(
                     real[key], sample[key], inner_non_strict)

--- a/abe/unittest.py
+++ b/abe/unittest.py
@@ -44,48 +44,50 @@ class AbeTestMixin(object):
         sample = normalize(sample)
         self.assertEqual(real, sample)
 
-    def assert_data_equal(self, real, sample, ignore=None):
+    def assert_data_equal(self, real, sample, non_strict=None):
         """
         Two elements are recursively equal
 
-        :param ignore:
-            Names of fields to ignore
+        :param non_strict:
+            Names of fields to match non-strictly. In current implementation,
+            only check for field presence.
         """
-        ignore = ignore or []
+        non_strict = non_strict or []
         try:
             if isinstance(real, list):
                 self.assertIsInstance(sample, list)
-                self.assert_data_list_equal(real, sample, ignore)
+                self.assert_data_list_equal(real, sample, non_strict)
             elif isinstance(real, dict):
                 self.assertIsInstance(sample, dict)
-                self.assert_data_dict_equal(real, sample, ignore)
+                self.assert_data_dict_equal(real, sample, non_strict)
             else:
                 self.assert_item_matches(real, sample)
         except AssertionError as exc:
             message = str(exc) + '\n{}\n{}\n\n'.format(real, sample)
             raise type(exc)(message)
 
-    def assert_data_dict_equal(self, real, sample, ignore=None):
+    def assert_data_dict_equal(self, real, sample, non_strict=None):
         """
         Two dicts are recursively equal without taking order into account
         """
-        ignore = ignore or []
+        non_strict = non_strict or []
         self.assertEqual(
             len(real), len(sample),
             msg='Number of elements mismatch: {} != {}\n'.format(
                 real.keys(), sample.keys())
         )
         for key in real:
-            if key not in ignore:
+            if key not in non_strict:
                 self.assertIn(key, sample)
-                inner_ignore = subkeys(ignore, key)
-                self.assert_data_equal(real[key], sample[key], inner_ignore)
+                inner_non_strict = subkeys(non_strict, key)
+                self.assert_data_equal(
+                    real[key], sample[key], inner_non_strict)
 
-    def assert_data_list_equal(self, real, sample, ignore=None):
+    def assert_data_list_equal(self, real, sample, non_strict=None):
         """
         Two lists are recursively equal, including ordering.
         """
-        ignore = ignore or []
+        non_strict = non_strict or []
         self.assertEqual(
             len(real), len(sample),
             msg='Number of elements mismatch: {} {}'.format(
@@ -95,7 +97,7 @@ class AbeTestMixin(object):
         exceptions = []
         for real_item, sample_item in zip(real, sample):
             try:
-                self.assert_data_equal(real_item, sample_item, ignore)
+                self.assert_data_equal(real_item, sample_item, non_strict)
             except AssertionError as exc:
                 exceptions.append(exc)
 
@@ -123,35 +125,44 @@ class AbeTestMixin(object):
                 "header {0}".format(expected_header)
             )
 
-    def assert_matches_request(self, sample_request, wsgi_request):
+    def assert_matches_request(self, sample_request, wsgi_request,
+                               non_strict=None):
         """
         Check that the sample request and wsgi request match.
         """
-        self.assertEqual(wsgi_request.META['PATH_INFO'], sample_request['url'])
-        self.assertEqual(wsgi_request.META['REQUEST_METHOD'],
-                         sample_request['method'])
+        non_strict = non_strict or []
 
-        if 'headers' in sample_request:
+        if 'url' not in non_strict:
+            self.assertEqual(wsgi_request.META['PATH_INFO'],
+                             sample_request['url'])
+        if 'method' not in non_strict:
+            self.assertEqual(wsgi_request.META['REQUEST_METHOD'],
+                             sample_request['method'])
+
+        if 'headers' in sample_request and 'headers' not in non_strict:
             self.assert_headers_contain(
                 wsgi_request.META, sample_request['headers']
             )
 
-        if 'body' in sample_request:
+        if 'body' in sample_request and 'body' not in non_strict:
             self.assert_data_equal(wsgi_request.POST, sample_request['body'])
 
     def assert_matches_response(self, sample_response, wsgi_response,
-                                ignore=None):
+                                non_strict=None):
         """
         Check that the sample response and wsgi response match.
         """
-        ignore = ignore or []
+        non_strict = non_strict or []
         self.assertEqual(wsgi_response.status_code, sample_response.status)
         if 'body' in sample_response:
             response_parsed = wsgi_response.data
             self.assert_data_equal(
-                response_parsed, sample_response.body, ignore)
+                response_parsed, sample_response.body, non_strict)
 
-    def assert_matches_sample(self, path, label, response, ignore=None):
+    def assert_matches_sample(
+        self, path, label, response, non_strict_response=None,
+        non_strict_request=None
+    ):
         """
         Check a URL and response against a sample.
 
@@ -162,15 +173,19 @@ class AbeTestMixin(object):
         :param response:
             The actual API response we want to match with the sample.
             It is assumed to be a Django Rest Framework response object
-        :param ignore:
+        :param non_strict:
             List of fields that will not be checked for strict matching.
             You can use this to include server-generated fields whose exact
             value you don't care about in your test, like ids, dates, etc.
         """
-        ignore = ignore or []
+        non_strict_response = non_strict_response or []
+        non_strict_request = non_strict_request or []
         sample = self.load_sample(path)
         sample_request = sample.examples[label].request
         sample_response = sample.examples[label].response
 
-        self.assert_matches_response(sample_response, response, ignore=ignore)
-        self.assert_matches_request(sample_request, response.wsgi_request)
+        self.assert_matches_response(
+            sample_response, response, non_strict=non_strict_response)
+        self.assert_matches_request(
+            sample_request, response.wsgi_request,
+            non_strict=non_strict_request)

--- a/abe/unittest.py
+++ b/abe/unittest.py
@@ -1,7 +1,7 @@
 import os
 
 from .mocks import AbeMock
-from .utils import to_unicode
+from .utils import normalize, subkeys
 
 
 class AbeTestMixin(object):
@@ -33,53 +33,69 @@ class AbeTestMixin(object):
         sample_request = sample.examples[label].request
         return sample_request.body
 
-    def assert_data_equal(self, data1, data2):
+    def assert_item_matches(self, real, sample):
+        """
+        A primitive value matches the sample.
+
+        If the sample represents a parameter, then do simple pattern matching.
+
+        """
+        real = normalize(real)
+        sample = normalize(sample)
+        self.assertEqual(real, sample)
+
+    def assert_data_equal(self, real, sample, ignore=None):
         """
         Two elements are recursively equal
+
+        :param ignore:
+            Names of fields to ignore
         """
+        ignore = ignore or []
         try:
-            if isinstance(data1, list):
-                self.assertIsInstance(data2, list)
-                self.assert_data_list_equal(data1, data2)
-            elif isinstance(data1, dict):
-                self.assertIsInstance(data2, dict)
-                self.assert_data_dict_equal(data1, data2)
+            if isinstance(real, list):
+                self.assertIsInstance(sample, list)
+                self.assert_data_list_equal(real, sample, ignore)
+            elif isinstance(real, dict):
+                self.assertIsInstance(sample, dict)
+                self.assert_data_dict_equal(real, sample, ignore)
             else:
-                data1 = to_unicode(data1)
-                data2 = to_unicode(data2)
-                self.assertIsInstance(data2, data1.__class__)
-                self.assertEqual(data1, data2)
+                self.assert_item_matches(real, sample)
         except AssertionError as exc:
-            message = str(exc) + '\n{}\n{}\n\n'.format(data1, data2)
+            message = str(exc) + '\n{}\n{}\n\n'.format(real, sample)
             raise type(exc)(message)
 
-    def assert_data_dict_equal(self, data1, data2):
+    def assert_data_dict_equal(self, real, sample, ignore=None):
         """
         Two dicts are recursively equal without taking order into account
         """
+        ignore = ignore or []
         self.assertEqual(
-            len(data1), len(data2),
+            len(real), len(sample),
             msg='Number of elements mismatch: {} != {}\n'.format(
-                data1.keys(), data2.keys())
+                real.keys(), sample.keys())
         )
-        for key in data1:
-            self.assertIn(key, data2)
-            self.assert_data_equal(data1[key], data2[key])
+        for key in real:
+            if key not in ignore:
+                self.assertIn(key, sample)
+                inner_ignore = subkeys(ignore, key)
+                self.assert_data_equal(real[key], sample[key], inner_ignore)
 
-    def assert_data_list_equal(self, data1, data2):
+    def assert_data_list_equal(self, real, sample, ignore=None):
         """
         Two lists are recursively equal, including ordering.
         """
+        ignore = ignore or []
         self.assertEqual(
-            len(data1), len(data2),
+            len(real), len(sample),
             msg='Number of elements mismatch: {} {}'.format(
-                data1, data2)
+                real, sample)
         )
 
         exceptions = []
-        for element, element2 in zip(data1, data2):
+        for real_item, sample_item in zip(real, sample):
             try:
-                self.assert_data_equal(element, element2)
+                self.assert_data_equal(real_item, sample_item, ignore)
             except AssertionError as exc:
                 exceptions.append(exc)
 
@@ -123,16 +139,19 @@ class AbeTestMixin(object):
         if 'body' in sample_request:
             self.assert_data_equal(wsgi_request.POST, sample_request['body'])
 
-    def assert_matches_response(self, sample_response, wsgi_response):
+    def assert_matches_response(self, sample_response, wsgi_response,
+                                ignore=None):
         """
         Check that the sample response and wsgi response match.
         """
+        ignore = ignore or []
         self.assertEqual(wsgi_response.status_code, sample_response.status)
         if 'body' in sample_response:
             response_parsed = wsgi_response.data
-            self.assert_data_equal(response_parsed, sample_response.body)
+            self.assert_data_equal(
+                response_parsed, sample_response.body, ignore)
 
-    def assert_matches_sample(self, path, label, response):
+    def assert_matches_sample(self, path, label, response, ignore=None):
         """
         Check a URL and response against a sample.
 
@@ -143,10 +162,15 @@ class AbeTestMixin(object):
         :param response:
             The actual API response we want to match with the sample.
             It is assumed to be a Django Rest Framework response object
+        :param ignore:
+            List of fields that will not be checked for strict matching.
+            You can use this to include server-generated fields whose exact
+            value you don't care about in your test, like ids, dates, etc.
         """
+        ignore = ignore or []
         sample = self.load_sample(path)
         sample_request = sample.examples[label].request
         sample_response = sample.examples[label].response
 
-        self.assert_matches_response(sample_response, response)
+        self.assert_matches_response(sample_response, response, ignore=ignore)
         self.assert_matches_request(sample_request, response.wsgi_request)

--- a/abe/utils.py
+++ b/abe/utils.py
@@ -34,5 +34,5 @@ def normalize(data):
 
 def subkeys(ignore, key):
     new_keys = filter(lambda s: s.startswith(key + '.'), ignore)
-    new_keys = map(lambda s: s[len(key) + 1:], new_keys)
+    new_keys = list(map(lambda s: s[len(key) + 1:], new_keys))
     return new_keys

--- a/abe/utils.py
+++ b/abe/utils.py
@@ -16,15 +16,23 @@ def datetime_to_string(value):
     return representation
 
 
-def to_unicode(data):
+def normalize(data):
     """
     Ensure that dates, Decimals and strings become unicode
+
+    Integers, on the other hand, are not converted.
     """
     if isinstance(data, datetime):
         data = datetime_to_string(data)
-    else:
+    elif not isinstance(data, int):
         data = str(data)
 
     if not _PY3 and isinstance(data, str):
         data = unicode(data)
     return data
+
+
+def subkeys(ignore, key):
+    new_keys = filter(lambda s: s.startswith(key + '.'), ignore)
+    new_keys = map(lambda s: s[len(key) + 1:], new_keys)
+    return new_keys

--- a/abe/utils.py
+++ b/abe/utils.py
@@ -32,7 +32,15 @@ def normalize(data):
     return data
 
 
-def subkeys(ignore, key):
-    new_keys = filter(lambda s: s.startswith(key + '.'), ignore)
+def subkeys(original, key):
+    """
+    Takes a list of dot-hierarchical values and keeps only matching subkeys.
+
+    Example:
+
+    >>> subkeys(['one.two', 'one.three', 'four'], 'one')
+    ['two', 'three']
+    """
+    new_keys = filter(lambda s: s.startswith(key + '.'), original)
     new_keys = list(map(lambda s: s[len(key) + 1:], new_keys))
     return new_keys

--- a/ep.yml
+++ b/ep.yml
@@ -4,7 +4,7 @@ dependencies:
       version: ">=2.6.0"
       file: test-requirements.txt
 run:
-  - flake8 abe
+  - flake8 abe tests
   - coverage erase
   - coverage run --omit="*/tests/*","*$VIRTUAL_ENV*" -m unittest discover
   - coverage html

--- a/ep.yml
+++ b/ep.yml
@@ -8,6 +8,7 @@ run:
   - coverage erase
   - coverage run --omit="*/tests/*","*$VIRTUAL_ENV*" -m unittest discover
   - coverage html
+  - python -m doctest abe/utils.py
 publish:
   - git diff --exit-code
   - ep run

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@
 
 flake8
 coverage
+mock

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -223,7 +223,8 @@ class TestAssertMatchesResponse(TestCase, AbeTestMixin):
         }
 
         self.assert_matches_response(
-            self.sample_response, response, ignore=['id', 'url', 'author.url']
+            self.sample_response, response,
+            non_strict=['id', 'url', 'author.url']
         )
 
     def test_non_strict_list_value_matches(self):
@@ -255,7 +256,7 @@ class TestAssertMatchesResponse(TestCase, AbeTestMixin):
         }
 
         self.assert_matches_response(
-            sample, response, ignore=['contributors.id']
+            sample, response, non_strict=['contributors.id']
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+
+from abe.utils import subkeys
+
+
+class TestSubkeys(TestCase):
+    def test_subkeys(self):
+        new_keys = subkeys(['key.one', 'key.two', 'hello', 'keyring'], 'key')
+        self.assertEqual(new_keys, ['one', 'two'])


### PR DESCRIPTION
This provides an approach to _loose_ matching that doesn't require changes in the spec.
- `assert_matches_sample` includes an optional argument to skip matching certain response fields: it uses a hierarchical notation: e.g. `url`, `author.id`...
- Added more test coverage in general

See tests for usage examples.
