### PR TITLE
Bug in non-strict request

### DIFF
--- a/abe/unittest.py
+++ b/abe/unittest.py
@@ -144,8 +144,9 @@ class AbeTestMixin(object):
                 wsgi_request.META, sample_request['headers']
             )
 
-        if 'body' in sample_request and 'body' not in non_strict:
-            self.assert_data_equal(wsgi_request.POST, sample_request['body'])
+        if 'body' in sample_request:
+            self.assert_data_equal(
+                wsgi_request.POST, sample_request['body'], non_strict)
 
     def assert_matches_response(self, sample_response, wsgi_response,
                                 non_strict=None):

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -166,6 +166,12 @@ class TestAssertMatchesRequest(TestCase, AbeTestMixin):
                 self.sample_request, self.mock_wsgi_request
             )
 
+    def test_matches_non_strict(self):
+        self.mock_wsgi_request.POST = {'name': 'Something else'}
+        self.assert_matches_request(
+            self.sample_request, self.mock_wsgi_request, non_strict=['name']
+        )
+
 
 def _abe_wrap_response(response):
     abe_mock = AbeMock({


### PR DESCRIPTION
As the old adage says, "Untested code worketh not".

TODO:
- [x] Add tests
